### PR TITLE
docs: Add correct clone URL in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ To set up and run this project locally, follow these steps:
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/yourusername/helloworldmainlauncherclass.git
+   git clone https://github.com/NanowarOfSteel/HelloWorld.git
    ```
 
 2. Navigate into the project directory:
    ```bash
-   cd helloworldmainlauncherclass
+   cd HelloWorld
    ```
 
 3. Compile the Java file:


### PR DESCRIPTION
It seems like the URL in the readme hasn't been changed, so I fixed it.