### PR TITLE
docs: use correct clone URL in the docker section

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ Before building and running the Docker image, make sure you have the following i
 First, clone the repository containing the project and the Dockerfile to your local machine:
 
 ```bash
-git clone <your-repository-url>
-cd <your-repository-directory>
+git clone https://github.com/NanowarOfSteel/HelloWorld.git
+cd HelloWorld
 ```
 
 ### 2. Build the Docker image


### PR DESCRIPTION
This replaces the generic placeholders `<your-repository-url>` and `<your-repository-directory>` with the actual repository URL and correct directory name.