### PR TITLE
Added "THURSDAY 13 MARCH 2025: Bochum, Germany - Matrix" to tour schedule (readme.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,8 @@ Due to resource allocation issues there are only limited possibilities:
 
 - WEDNESDAY 12 MARCH 2025: Antwerp, Belgium - Kavka Zappa
 
+- THURSDAY 13 MARCH 2025: Bochum, Germany - Matrix
+
 - FRIDAY 14 MARCH 2025: Drachten, Netherlands - Poppodium Iduna
 
 - SATURDAY 15 MARCH 2025: Strasbourg, France - Le Molodoï


### PR DESCRIPTION
Added "THURSDAY 13 MARCH 2025: Bochum, Germany - Matrix" to tour schedule of the readme.md

Source: https://www.nanowar.it/live/